### PR TITLE
Add default config files back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-dat.json
-portal.json
 media/content
 !media/content/icon.svg

--- a/dat.json
+++ b/dat.json
@@ -1,0 +1,5 @@
+{
+  "url": "",
+  "title": "",
+  "description": ""
+}

--- a/portal.json
+++ b/portal.json
@@ -1,0 +1,10 @@
+{
+  "name": "new_name",
+  "desc": "new_desc",
+  "port": [
+    "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/"
+  ],
+  "feed": [],
+  "site": "",
+  "dat": ""
+}


### PR DESCRIPTION
Sorry about this.

So it looks like we need to keep the defaults in here. Otherwise whenever someone pulls they'll lose their `dat.json` and `portal.json` files.

You should run this instead to avoid future conflicts, as per https://stackoverflow.com/a/40272289:

```
git update-index --skip-worktree dat.json
git update-index --skip-worktree portal.json
```

Fixes #18.

Sorry again if this caused anyone issues.