### PR TITLE
added some display:blocks to sidebar elements for clarity

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -10,6 +10,8 @@ body #portal .desc { display:block; }
 body #portal .site { display:block; color:#999; margin-bottom:20px; }
 body #portal .port { display: block }
 body #portal .feed { display:block; }
+body #portal .port_status { display:block; }
+body #portal .port_list { display:block; }
 body #portal .port_list list { display:block; margin-top:15px; columns:2;}
 body #portal .port_list list ln { display: block; font-size:11px; line-height: 15px;  }
 body #portal .port_list list ln t:hover { text-decoration: underline; cursor: pointer; }


### PR DESCRIPTION
Added two `display:block` styles to `.port_status` and `.port_list` in the sidebar to stop this:
<img width="257" alt="screen shot 2017-10-13 at 10 05 39 pm" src="https://user-images.githubusercontent.com/556484/31572791-afaa0a7c-b062-11e7-9116-f25202070248.png">
