### PR TITLE
Set display icon as favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <script src="/scripts/feed.js"></script>
     <script src="/scripts/entry.js"></script>
     <script src="/scripts/operator.js"></script>
+
+    <link rel="icon" type="image/svg" href="/media/content/icon.svg" sizes="any" />
   </head>
   <body></body>
   <script>


### PR DESCRIPTION
Beaker Browser supports SVG icons (as the favicons are just displayed in <img> tags), Rotonde should just use the user icons as the site favicons.