### PR TITLE
 Fix forced image width issue

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -42,7 +42,7 @@ body #feed .entry .timestamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .editstamp { color:#aaa; font-size:11px; }
 body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
-body #feed .entry .media { max-width: 500px; width:100%; margin-top:15px; display:block; margin-bottom:15px; border-radius:4px; }
+body #feed .entry .media { max-width: 500px; margin-top:15px; display:block; margin-bottom:15px; border-radius:4px; }
 
 body #operator { background: #eee;width: calc(100vw - 420px);max-width: 500px;margin-left: 270px;margin-top: 40px;border-bottom: 1px solid #000; position: relative;}
 body #operator input { display: block; padding:15px; background:transparent; color:black; width: calc(100% - 105px);}


### PR DESCRIPTION
`@ariganu` on rotonde mentioned an issue with images smaller than 500px in width being scaled up:

![screen shot 2017-10-15 at 11 22 01 am](https://user-images.githubusercontent.com/17946150/31580428-38fed648-b19b-11e7-9193-deb480164e62.png)

This will fix that issue. Since the same css rule has a max-width of 500px, the image will still be contained within the parent's boundaries.