### PR TITLE
Added drag/drop image uploader

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -50,4 +50,5 @@ body #feed .entry .media { max-width: 500px; margin-top:15px; display:block; mar
 
 body #operator { background: #eee;width: calc(100vw - 420px);max-width: 600px;margin-left: 270px;margin-top: 40px;border-bottom: 1px solid #000; position: relative;}
 body #operator input { display: block; padding:15px; background:transparent; color:black; width: calc(100% - 105px);}
+body #operator input.drag { background: #b7b7b7; }
 body #operator #hint { position: absolute;top: 0px;right: 0px;padding: 15px;display: block; line-height: 14px; color:#aaa;}

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -13,6 +13,9 @@ function Operator()
 
     this.input_el.addEventListener('keydown',r.operator.key_down, false);
     this.input_el.addEventListener('input',r.operator.input_changed, false);
+    this.input_el.addEventListener('dragover',r.operator.drag_over, false);
+    this.input_el.addEventListener('dragleave',r.operator.drag_leave, false);
+    this.input_el.addEventListener('drop',r.operator.drop, false);
     this.update();
   }
 
@@ -86,7 +89,7 @@ function Operator()
     }
 
     console.log(r.portal.data.site);
-    
+
     r.portal.save();
     r.portal.update();
     r.feed.update();
@@ -163,5 +166,52 @@ function Operator()
   this.input_changed = function(e)
   {
     r.operator.update();
+  }
+
+  this.drag = function(bool)
+  {
+    if (bool) {
+      this.input_el.classList.add('drag')
+    } else {
+      this.input_el.classList.remove('drag')
+    }
+  }
+
+  this.drag_over = function(e)
+  {
+    e.preventDefault();
+    r.operator.drag(true);
+  }
+
+  this.drag_leave = function(e)
+  {
+    e.preventDefault();
+    r.operator.drag(false);
+  }
+
+  this.drop = function(e)
+  {
+    e.preventDefault();
+
+    var files = e.dataTransfer.files;
+    if (files.length === 1) {
+      var file = files[0];
+      var type = file.type;
+
+      if (type === 'image/jpg' || type === 'image/png' || type === 'image/gif') {
+        var reader = new FileReader();
+        reader.onload = async function (e) {
+          var result = e.target.result;
+
+          var archive = new DatArchive(window.location.toString());
+          await archive.writeFile('/media/content/' + file.name, result);
+          await archive.commit();
+
+          r.operator.inject('text_goes_here >> ' + file.name);
+        }
+        reader.readAsArrayBuffer(file);
+      }
+    }
+    r.operator.drag(false);
   }
 }


### PR DESCRIPTION
Users can now post images to their feeds by simply dragging and dropping onto the commander input:

![image-upload-pr3](https://user-images.githubusercontent.com/17946150/31607760-52df19f0-b2b9-11e7-85d6-fb40153ce6e3.gif)

I've tried to follow the general style of the codebase as much as possible, but it might not be perfect. I'm sure it can be improved, so all suggestions welcome.