### PR TITLE
fixed a regex that was creating malformed URLs

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -77,9 +77,13 @@ function Entry(data)
         n.push("<c class='hashtag' data-operation='filter "+word+"'>"+word+"</c>");
       }
       else if (word.search(/^https?:\/\//) != -1) {
-        var url = new URL(word)
-        var compressed = word.substr(word.indexOf("://")+3,url.hostname.length + 15)+"..";
-        n.push("<a href='"+url.href+"'>"+compressed+"</a>");
+        try {
+          var url = new URL(word)
+          var compressed = word.substr(word.indexOf("://")+3,url.hostname.length + 15)+"..";
+          n.push("<a href='"+url.href+"'>"+compressed+"</a>");
+        } catch(e) {
+          console.error("Error when parsing url:", word, e);
+          n.push(word);
       }
       else{
         n.push(word)

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -76,7 +76,7 @@ function Entry(data)
       else if(word.substr(0,1) == "#"){
         n.push("<c class='hashtag' data-operation='filter "+word+"'>"+word+"</c>");
       }
-      else if (word.search(/https?:\/\//) != -1) {
+      else if (word.search(/^https?:\/\//) != -1) {
         var url = new URL(word)
         var compressed = word.substr(word.indexOf("://")+3,url.hostname.length + 15)+"..";
         n.push("<a href='"+url.href+"'>"+compressed+"</a>");


### PR DESCRIPTION
This message:
`What about encoding our portal.json with msgpack5? (https://www.npmjs.com/package/msgpack5) [...]`
was causing rotonde to try to parse the brackets as part of the URL, which failed and threw an exception, preventing the feed from rendering.

This PR adds a tiny regex fix to prevent that from happening by ignoring URLs that don't start with http(s)://