### PR TITLE
fix(Entry): add missing curly bracket

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -84,6 +84,7 @@ function Entry(data)
         } catch(e) {
           console.error("Error when parsing url:", word, e);
           n.push(word);
+        }
       }
       else{
         n.push(word)


### PR DESCRIPTION
Latest update relating to the malformed URLs left me with this syntax error:

![screen shot 2017-10-16 at 21 37 45](https://user-images.githubusercontent.com/578381/31631579-67013eda-b2ba-11e7-9dd2-f51391150b2f.png)

This fixes it.