### PR TITLE
cblgh/tweaks: add tabbing, fix @names in, closes #47

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -21,7 +21,7 @@ function Entry(data)
 
     html += "<a href='"+this.dat+"'><img class='icon' src='"+this.dat+"/media/content/icon.svg'></a>";
 
-    html += "<t class='portal'><a href='"+this.dat+"'>"+(this.seed ? "@" : "~")+this.portal+"</a>"+(this.target ? " > <a href='"+this.target+"'>"+(this.message.split(" ")[0])+"</a>" : "")+"</t>";
+    html += "<t class='portal'><a href='"+this.dat+"'>"+(this.seed ? "@" : "~")+this.portal+"</a>"+(this.target ? " > <a href='"+this.target+"'>"+("@"+r.operator.name_pattern.exec(this.message)[1])+"</a>" : "")+"</t>";
 
     if(this.portal == r.portal.data.name){
       html += this.editstamp ? "<c class='editstamp' data-operation='"+('edit:'+this.id+' '+this.message.replace("'",""))+"'>edited "+timeSince(this.editstamp)+" ago</c>" : "<c class='timestamp' data-operation='edit:"+this.id+" "+this.message.replace("'","")+"'>"+timeSince(this.timestamp)+" ago</c>";

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -104,8 +104,10 @@ function Entry(data)
     var n = [];
     for(id in words){
       var word = words[id];
-      if(word.substr(0,1) == "@" && r.feed.portals[word.substr(1,word.length-1)]){
-        n.push("<a href='"+r.feed.portals[word.substr(1,word.length-1)].dat+"' class='known_portal'>"+word+"</a>");
+      var name_match = r.operator.name_pattern.exec(word)
+      if(name_match && r.feed.portals[name_match[1]]){
+        var remnants = word.substr(name_match[0].length)
+        n.push("<a href='"+r.feed.portals[name_match[1]].dat+"' class='known_portal'>"+name_match[0]+"</a>"+remnants);
       }
       else{
         n.push(word)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -167,6 +167,22 @@ function Operator()
       r.reset();
       return;
     }
+
+    if(e.key == "Tab") {
+        e.preventDefault();
+        var words = r.operator.input_el.value.split(" ")
+        var last = words[words.length - 1]
+        var name_match = r.operator.name_pattern.exec(last);
+        if (name_match) {
+            for (var portal_name in r.feed.portals) {
+                if (portal_name && portal_name.substr(0, name_match[1].length) === name_match[1]) {
+                    words[words.length - 1] = "@" + portal_name;
+                    r.operator.inject(words.join(" "));
+                    return;
+                }
+            }
+        }
+    }
     r.operator.update();
   }
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -6,6 +6,7 @@ function Operator()
   this.hint_el = document.createElement('t'); this.hint_el.id = "hint";
   this.el.appendChild(this.input_el);
   this.el.appendChild(this.hint_el);
+  this.name_pattern = new RegExp(/^@(\w+)/, "i");
 
   this.install = function(el)
   {
@@ -51,6 +52,7 @@ function Operator()
 
   this.commands = {};
 
+  // catches neauoire from @neauoire
   this.commands.say = function(p)
   {
     var message = p;
@@ -65,8 +67,11 @@ function Operator()
     if(media){
       data.media = media;
     }
+    // if message starts with an @ symbol, then we're doing a mention
     if(message.indexOf("@") == 0){
-      var name = message.split(" ")[0].replace("@","").trim();
+      var name = message.split(" ")[0]
+      // execute the regex & get the first matching group (i.e. no @, only the name)
+      name = r.operator.name_pattern.exec(name)[1]
       if(r.feed.portals[name]){
         data.target = r.feed.portals[name].dat;  
       }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -194,7 +194,6 @@ function Operator()
   this.drop = function(e)
   {
     e.preventDefault();
-
     var files = e.dataTransfer.files;
     if (files.length === 1) {
       var file = files[0];
@@ -209,7 +208,12 @@ function Operator()
           await archive.writeFile('/media/content/' + file.name, result);
           await archive.commit();
 
-          r.operator.inject('text_goes_here >> ' + file.name);
+          var commanderText = 'text_goes_here >> ' + file.name 
+          // if there's  already a message written, append ">> file.name" to it
+          if (r.operator.input_el.value) {
+              commanderText = r.operator.input_el.value.trim() + " >> " + file.name;
+          }
+          r.operator.inject(commanderText);
         }
         reader.readAsArrayBuffer(file);
       }

--- a/scripts/rotonde.js
+++ b/scripts/rotonde.js
@@ -52,6 +52,7 @@ function Rotonde()
         portal_data = JSON.parse(portal_str);
       } catch (err) {
         // TODO: handle invalid portal.json
+        console.error("Malformed JSON in portal.json")
       }
     }
 


### PR DESCRIPTION
pretty much what the title says, operator.js now has a regex that can be accessed using r.operator.name_pattern and which is used to match names wherever names are matched.

less janky than splitting on whitespace and a bit cleaner.

also added was support for tab-completing names. but check the individual commits for more info.