### PR TITLE
Also handle image/jpeg mimetype

### DIFF
--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -239,7 +239,7 @@ function Operator()
       var file = files[0];
       var type = file.type;
 
-      if (type === 'image/jpeg' || type === 'image/png' || type === 'image/gif') {
+      if (type === 'image/jpg' || type === 'image/jpeg' || type === 'image/png' || type === 'image/gif') {
         var reader = new FileReader();
         reader.onload = async function (e) {
           var result = e.target.result;


### PR DESCRIPTION
On my MacBook, I was getting this mimetype when I tried to drag-and-drop
an image from the Finder.

Fixes: #70